### PR TITLE
[v1] Fix travis

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,9 @@
 node_modules
 bower_components
 
+# Nightwatch Test Artifacts
+screenshots
+
 # Runtime
 .DS_Store
 *.log

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,8 @@ language: node_js
 node_js:
 - '6'
 before_script:
-- npm install
 - npm install -g bower
+- yarn
 - bower install
 script: gulp test
 cache:

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,15 +2,16 @@ sudo: true
 dist: trusty
 language: node_js
 node_js:
-- '6'
+  - '6'
 before_script:
-- npm install -g bower
-- yarn
-- bower install
-script: gulp test
+  - npm install -g bower web-component-tester
+  - yarn
+  - bower install
+  - gulp build:tests
+script: xvfb-run wct 
 cache:
  directories:
- - node_modules
+   - node_modules
 addons:
   firefox: latest
   apt:

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,10 +8,8 @@ before_script:
   - yarn
   - bower install
   - gulp build:tests
-script: xvfb-run wct 
-cache:
- directories:
-   - node_modules
+script: xvfb-run wct
+cache: yarn
 addons:
   firefox: latest
   apt:

--- a/test/core.html
+++ b/test/core.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8">
     <title>simpla-text</title>
-    <script src="../../webcomponentsjs/webcomponents.min.js"></script>
+    <script src="../../webcomponentsjs/webcomponents-lite.min.js"></script>
     <script src="../../web-component-tester/browser.js"></script>
 
     <!-- Test Helpers -->

--- a/test/index.html
+++ b/test/index.html
@@ -2,7 +2,7 @@
 <html>
   <head>
     <meta charset="utf-8">
-    <script src="../bower_components/webcomponentsjs/webcomponents-lite.js"></script>
+    <script src="../bower_components/webcomponentsjs/webcomponents-lite.min.js"></script>
     <script src="../bower_components/web-component-tester/browser.js"></script>
   </head>
   <body>

--- a/test/inline.html
+++ b/test/inline.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8">
     <title>simpla-text</title>
-    <script src="../../webcomponentsjs/webcomponents.min.js"></script>
+    <script src="../../webcomponentsjs/webcomponents-lite.min.js"></script>
     <script src="../../web-component-tester/browser.js"></script>
 
     <!-- Test Helpers -->

--- a/test/inline.html
+++ b/test/inline.html
@@ -44,20 +44,20 @@
           });
 
           it('should not allow `p` tags', () => {
-            component.innerHTML = '<p>Hello World</p>';
+            component.value = '<p>Hello World</p>';
 
             return flushEditor(component)
               .then(() => {
-                expect(component.innerHTML).to.equal('Hello World');
+                expect(component.value).to.equal('Hello World');
               });
           });
 
           it('should allow `br` tags', () => {
-            component.innerHTML = 'Hello<br />World';
+            component.value = 'Hello<br />World';
 
             return flushEditor(component)
               .then(() => {
-                expect(component.innerHTML).to.match(/\<br/);
+                expect(component.value).to.match(/\<br/);
               });
           });
 
@@ -76,20 +76,20 @@
 
         describe(description || 'formats content as block', () => {
           it('should allow `p` tags', () => {
-            component.innerHTML = '<p>Hello World</p>';
+            component.value = '<p>Hello World</p>';
 
             return flushEditor(component)
               .then(() => {
-                expect(component.innerHTML).to.match(/<p/);
+                expect(component.value).to.match(/<p/);
               });
           });
 
           it('should default to empty `p` tag when no content is set', () => {
-            component.innerHTML = '';
+            component.value = '';
 
             return flushEditor(component)
               .then(() => {
-                expect(component.innerHTML).to.match(/<p/);
+                expect(component.value).to.match(/<p/);
               });
           });
 

--- a/test/simpla-connector.html
+++ b/test/simpla-connector.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8">
     <title>simpla-text</title>
-    <script src="../../webcomponentsjs/webcomponents.min.js"></script>
+    <script src="../../webcomponentsjs/webcomponents-lite.min.js"></script>
     <script src="../../web-component-tester/browser.js"></script>
 
     <!-- Test Helpers -->


### PR DESCRIPTION
Fixes Travis CI continually failing. Uses `yarn` over `npm`, fixes tests including incorrect polyfills, uses `xvfb` to get wct to work properly, and uses [`yarn` caching](https://blog.travis-ci.com/2016-11-21-travis-ci-now-supports-yarn). Also updates the tests to use `value` prop when testing text contents. 